### PR TITLE
Fix crash in factsheets from undefined data when typing single letters

### DIFF
--- a/src/components/Factsheets.tsx
+++ b/src/components/Factsheets.tsx
@@ -329,7 +329,7 @@ const Factsheets = () => {
         size: 180, // This is the default value, but it stops the column from changing when the table is resized
         Cell: ({ cell }) => (
           <span>
-            {cell.getValue && addDictionaryDefs(cell.getValue<string>())}
+            {cell.getValue() ? addDictionaryDefs(cell.getValue<string>()) : ""}
           </span>
         ),
       },
@@ -343,7 +343,7 @@ const Factsheets = () => {
         size: 180, // This is the default value, but it stops the column from changing when the table is resized
         Cell: ({ cell }) => (
           <span>
-            {cell.getValue && addDictionaryDefs(cell.getValue<string>())}
+            {cell.getValue() ? addDictionaryDefs(cell.getValue<string>()) : ""}
           </span>
         ),
       },
@@ -356,7 +356,7 @@ const Factsheets = () => {
         size: 900, // Make this one bigger because of the long text
         Cell: ({ cell }) => (
           <span>
-            {cell.getValue && addDictionaryDefs(cell.getValue<string>())}
+            {cell.getValue() ? addDictionaryDefs(cell.getValue<string>()) : ""}
           </span>
         ),
       },


### PR DESCRIPTION
There was a bug where if you input a single letter in multiple of the factsheet input fields, it would crash. This resolves that error by making sure undefined rows are not passed to addDictionaryDefs. Seems to all work fine on my end and I compared results from both the live site and local to verify data still looked fine.

Credit to virtualymichael from the Discord for reporting the problem.

Fix #144.